### PR TITLE
Fix NextDivisibleByN bug

### DIFF
--- a/pkg/utils/main.go
+++ b/pkg/utils/main.go
@@ -364,10 +364,13 @@ func StringToInt64(s string) int64 {
 }
 
 func NextDivisibleByN(i, n int) int {
+	if n == 0 {
+		return i
+	}
 	if i%n == 0 {
 		return i
 	}
-	return ((i / n) + 1) * 10000
+	return ((i / n) + 1) * n
 }
 
 func GetUnitsecs(frequency int) int64 {

--- a/pkg/utils/main_test.go
+++ b/pkg/utils/main_test.go
@@ -105,3 +105,24 @@ func Test_Str2date(t *testing.T) {
 		})
 	}
 }
+
+func Test_NextDivisibleByN(t *testing.T) {
+	tests := []struct {
+		i        int
+		n        int
+		expected int
+	}{
+		{0, 5, 0},
+		{10, 5, 10},
+		{11, 5, 15},
+		{23, 7, 28},
+		{9, 0, 9},
+	}
+
+	for _, tt := range tests {
+		got := NextDivisibleByN(tt.i, tt.n)
+		if got != tt.expected {
+			t.Errorf("NextDivisibleByN(%d, %d) = %d, want %d", tt.i, tt.n, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- fix incorrect calculation in `NextDivisibleByN`
- add dedicated test coverage

## Testing
- `go test ./...` *(fails: forbidden module download)*

------
https://chatgpt.com/codex/tasks/task_e_68418e040cd08323a9554d74f76c6b05